### PR TITLE
Ignore lint errors on CLI build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,9 @@ android {
             path 'CMakeLists.txt'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 repositories {
     jcenter()


### PR DESCRIPTION
When running gradlew (CLI) the build would fail on lint errors without the modified build.gradle.