### PR TITLE
Handle Google API Connection Problems + UI Fixes

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -53,7 +53,7 @@ public class MagiskHideFragment extends Fragment {
             new LoadApps().exec();
         });
 
-        recyclerView.setAdapter(appAdapter);
+        recyclerView.swapAdapter(appAdapter, true);
 
         searchListener = new SearchView.OnQueryTextListener() {
             @Override

--- a/app/src/main/java/com/topjohnwu/magisk/StatusFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/StatusFragment.java
@@ -221,6 +221,16 @@ public class StatusFragment extends Fragment implements CallbackHandler.EventLis
         int image, color;
         safetyNetProgress.setVisibility(View.GONE);
         switch (SNCheckResult) {
+            case -3:
+                color = colorNeutral;
+                image = R.drawable.ic_help;
+                safetyNetStatusText.setText(R.string.safetyNet_connection_suspended);
+                break;
+            case -2:
+                color = colorNeutral;
+                image = R.drawable.ic_help;
+                safetyNetStatusText.setText(R.string.safetyNet_connection_failed);
+                break;
             case -1:
                 color = colorNeutral;
                 image = R.drawable.ic_help;

--- a/app/src/main/java/com/topjohnwu/magisk/utils/SafetyNetHelper.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/SafetyNetHelper.java
@@ -32,6 +32,7 @@ public abstract class SafetyNetHelper
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult result) {
         Logger.dev("SN: Google API fail");
+        handleResults(-2);
     }
 
     @Override
@@ -43,6 +44,7 @@ public abstract class SafetyNetHelper
     @Override
     public void onConnectionSuspended(int i) {
         Logger.dev("SN: Google API Suspended");
+        handleResults(-3);
     }
 
     public void requestTest() {

--- a/app/src/main/res/layout/list_item_repo.xml
+++ b/app/src/main/res/layout/list_item_repo.xml
@@ -69,7 +69,8 @@
                 android:layout_gravity="center_vertical"
                 android:text="@string/no_info_provided"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textIsSelectable="false"/>
+                android:textIsSelectable="false"
+                android:layout_alignEnd="@+id/author" />
 
             <ImageView
                 android:id="@+id/update"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="not_rooted">Not rooted</string>
     <string name="proper_root">Properly rooted</string>
     <string name="checking_safetyNet_status">Checking SafetyNet status…</string>
+    <string name="safetyNet_connection_failed">Cannot connect to Google API</string>
+    <string name="safetyNet_connection_suspended">Connection to Google API was suspended</string>
     <string name="safetyNet_error">Cannot check SafetyNet, no Internet?</string>
     <string name="safetyNet_fail">SafetyNet Failed: CTS profile mismatch</string>
     <string name="safetyNet_pass">SafetyNet Passed</string>


### PR DESCRIPTION
1. The Google API connection problem is not handled, thus it will perform cycling and cycling on the main screen.

  Properly handle them by calling handleResults.

2. Sometimes setAdapter is unreliable, use swapAdapter instead, tested ok, will close #41. 

  Edit: Seems it will still crash when scrolling for a long time and refresh (very rare), wtf....... I will try to find a proper fix, but anyway you can merge it in advance.

3. Fix the overlay issue, it has been there since 2.0.