### PR TITLE
Various fixes for string resources

### DIFF
--- a/app/src/main/res/values-ar/arrays.xml
+++ b/app/src/main/res/values-ar/arrays.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="themes">
-        <item>"إفتراضي"</item>
-        <item>"غامق"</item>
-    </string-array>
-</resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -85,6 +85,8 @@
     <string name="settings_general_category">عام</string>
     <string name="settings_theme_title">السمة</string>
     <string name="settings_theme_summary">أختر سمة</string>
+    <string name="theme_default">إفتراضي</string>
+    <string name="theme_dark">غامق</string>
 
     <string name="settings_magiskhide_title">تمكين إخفاء Magisk</string>
     <string name="settings_magiskhide_summary">إخفاء Magisk من مختلف حالات الإكتشاف</string>

--- a/app/src/main/res/values-de/arrays.xml
+++ b/app/src/main/res/values-de/arrays.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="themes">
-        <item>"Standard"</item>
-        <item>"Dunkel"</item>
-    </string-array>
-</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,7 +3,7 @@
 
     <!--Welcome Activity-->
     <string name="navigation_drawer_open">Navigationsleiste öffnen</string>
-    <string name="navigation_drawer_close">Navigationsleiste schliessen</string>
+    <string name="navigation_drawer_close">Navigationsleiste schließen</string>
     <string name="modules">Module</string>
     <string name="downloads">Downloads</string>
     <string name="log">Log</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -80,6 +80,9 @@
     <string name="settings_general_category">Allgemein</string>
     <string name="settings_theme_title">Aussehen</string>
     <string name="settings_theme_summary">Wähle ein Theme aus</string>
+    <string name="theme_default">Standard</string>
+    <string name="theme_dark">Dunkel</string>
+
     <string name="settings_busybox_title">BusyBox aktivieren</string>
     <string name="settings_busybox_summary">Magisks eingebautes BusyBox zum PATH hinzufügen</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -49,7 +49,7 @@
     <string name="app_developers">Entwickler</string>
     <string name="app_developers_"><![CDATA[Anwendung entwickelt von <a href="https://github.com/topjohnwu">topjohnwu</a> in Zusammenarbeit mit <a href="https://github.com/d8ahazard">Digitalhigh</a> und <a href="https://github.com/dvdandroid">Dvdandroid</a>.]]></string>
     <string name="app_changelog">Anwendungs changelog</string>
-    <string name="translators" />
+    <string name="translators">skalnet</string>
     <string name="app_version">Anwendungs Version</string>
     <string name="app_source_code">Quelltext</string>
     <string name="donation">Spende</string>

--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="themes">
-        <item>"Por defecto"</item>
-        <item>"Oscuro"</item>
-    </string-array>
-</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -82,6 +82,8 @@
     <string name="settings_general_category">General</string>
     <string name="settings_theme_title">Tema</string>
     <string name="settings_theme_summary">Selecciona un tema</string>
+    <string name="theme_default">Por defecto</string>
+    <string name="theme_dark">Oscuro</string>
 
     <string name="settings_magiskhide_title">Habilitar Magisk Hide</string>
     <string name="settings_magiskhide_summary">Ocultar Magisk de varias detecciones</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,7 +51,7 @@
     <string name="app_developers">Desarroladores principales</string>
     <string name="app_developers_"><![CDATA[App created by <a href="https://github.com/topjohnwu">topjohnwu</a> in collaboration with <a href="https://github.com/d8ahazard">Digitalhigh</a> and <a href="https://github.com/dvdandroid">Dvdandroid</a>.]]></string>
     <string name="app_changelog">Cambios en la aplicación</string>
-    <string name="translators"/>
+    <string name="translators">Gawenda, netizen</string>
     <string name="app_version">Versión de la aplicación</string>
     <string name="app_source_code">Código fuente</string>
     <string name="donation">Donar</string>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="themes">
-        <item>"Default"</item>
-        <item>"Scuro"</item>
-    </string-array>
-</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -49,7 +49,7 @@
     <string name="app_developers">Sviluppatori</string>
     <string name="app_developers_"><![CDATA[App creata da <a href="https://github.com/topjohnwu">topjohnwu</a> in collaborazione con <a href="https://github.com/d8ahazard">Digitalhigh</a> e <a href="https://github.com/dvdandroid">Dvdandroid</a>.]]></string>
     <string name="app_changelog">Changelog</string>
-    <string name="translators" />
+    <string name="translators">Fabb2303</string>
     <string name="app_version">Versione App</string>
     <string name="app_source_code">Codice sorgente</string>
     <string name="donation">Donazione</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -80,6 +80,9 @@
     <string name="settings_general_category">Generali</string>
     <string name="settings_theme_title">Tema</string>
     <string name="settings_theme_summary">Scegli un tema</string>
+    <string name="theme_default">Default</string>
+    <string name="theme_dark">Scuro</string>
+
     <string name="settings_busybox_title">Abilita BusyBox</string>
     <string name="settings_busybox_summary">Make Magisk\'s built-in BusyBox be visible in PATH</string>
 

--- a/app/src/main/res/values-nl/arrays.xml
+++ b/app/src/main/res/values-nl/arrays.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="themes">
-        <item>"Standaard"</item>
-        <item>"Donker"</item>
-    </string-array>
-</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -93,7 +93,6 @@
     <string name="settings_shell_logging_summary">Schakel dit in om alle shell commands en output te loggen</string>
     <string name="settings_magiskhide_title">Magisk verbergen</string>
     <string name="settings_magiskhide_summary">Reboot om de instellingen toe te passen</string>
-    <string name="zip_install_unzip_zip_msg"></string>
 
     <!-- Strings related to Settings -->
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -49,7 +49,7 @@
     <string name="app_developers">Hoofddevelopers</string>
     <string name="app_developers_"><![CDATA[App gemaakt door <a href="https://github.com/topjohnwu">topjohnwu</a> in samenwerking met <a href="https://github.com/d8ahazard">Digitalhigh</a> en <a href="https://github.com/dvdandroid">Dvdandroid</a>.]]></string>
     <string name="app_changelog">App\'s changelog</string>
-    <string name="translators" />
+    <string name="translators">NaamloosDT, Klaessen</string>
     <string name="app_version">App\'s versie</string>
     <string name="app_source_code">Source code</string>
     <string name="donation">Donatie</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -80,6 +80,9 @@
     <string name="settings_general_category">Algemeen</string>
     <string name="settings_theme_title">Thema</string>
     <string name="settings_theme_summary">Selecteer een thema</string>
+    <string name="theme_default">Standaard</string>
+    <string name="theme_dark">Donker</string>
+
     <string name="settings_busybox_title">Schakel BusyBox in</string>
     <string name="settings_busybox_summary">Maakt Magisk\'s ingebouwde BusyBox zichtbaar in PATH</string>
 

--- a/app/src/main/res/values-pt/arrays.xml
+++ b/app/src/main/res/values-pt/arrays.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="themes">
-        <item>"Padrão"</item>
-        <item>"Escuro"</item>
-    </string-array>
-</resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -78,6 +78,9 @@
     <string name="settings_general_category">Geral</string>
     <string name="settings_theme_title">Tema</string>
     <string name="settings_theme_summary">Escolha um tema</string>
+    <string name="theme_default">Padrão</string>
+    <string name="theme_dark">Escuro</string>
+
     <string name="settings_busybox_title">Ativar BusyBox</string>
     <string name="settings_busybox_summary">Marque essa opção para o BusyBox do Magisk ser visível no PATH</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -47,7 +47,7 @@
     <string name="app_developers">Principais desenvolvedores</string>
     <string name="app_developers_"><![CDATA[App criado por <a href="https://github.com/topjohnwu">topjohnwu</a> em colaboração com <a href="https://github.com/d8ahazard">Digitalhigh</a> e <a href="https://github.com/dvdandroid">Dvdandroid</a>.]]></string>
     <string name="app_changelog">Registro de Mudanças do App</string>
-    <string name="translators" />
+    <string name="translators">Killer7Mod</string>
     <string name="app_version">Versão do App</string>
     <string name="app_source_code">Código fonte</string>
     <string name="donation">Doação</string>

--- a/app/src/main/res/values-zh-rCN/arrays.xml
+++ b/app/src/main/res/values-zh-rCN/arrays.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="themes">
-        <item>"默认"</item>
-        <item>"深色"</item>
-    </string-array>
-</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -106,6 +106,8 @@
     <string name="settings_general_category">常规</string>
     <string name="settings_theme_title">主题</string>
     <string name="settings_theme_summary">选择一个主题</string>
+    <string name="theme_default">默认</string>
+    <string name="theme_dark">深色</string>
 
     <string name="settings_magiskhide_title">启用 Magisk 隐藏</string>
     <string name="settings_magiskhide_summary">隐藏 Magisk 使其不被多种方法检测到</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -69,7 +69,7 @@
     <string name="app_developers">主要开发者</string>
     <string name="app_developers_"><![CDATA[此应用由 <a href="https://github.com/topjohnwu">topjohnwu</a> 与 <a href="https://github.com/d8ahazard">Digitalhigh</a> 和 <a href="https://github.com/dvdandroid">Dvdandroid</a> 合作开发。]]></string>
     <string name="app_changelog">应用更新日志</string>
-    <string name="translators" />
+    <string name="translators">gh2923</string>
     <string name="app_version">应用版本</string>
     <string name="app_source_code">源代码</string>
     <string name="donation">捐赠</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="themes">
-        <item>"Default"</item>
-        <item>"Dark"</item>
+        <item>@string/theme_default</item>
+        <item>@string/theme_dark</item>
     </string-array>
     <string-array name="themes_values">
         <item>@string/theme_default_value</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,8 @@
     <string name="settings_general_category">General</string>
     <string name="settings_theme_title">Theme</string>
     <string name="settings_theme_summary">Select a theme</string>
+    <string name="theme_default">Default</string>
+    <string name="theme_dark">Dark</string>
 
     <string name="settings_magiskhide_title">Enable Magisk Hide</string>
     <string name="settings_magiskhide_summary">Hide Magisk from various detections</string>


### PR DESCRIPTION
The first commit is the most important one: string-arrays should always contain string references if they are meant to be translated!
Indeed, the translations editor bundled with Android Studio does not show strings in arrays, thus you cannot translate them without doing it manually.
Last but not least, this will guarantee that your array contains the same number of items regardless of the locale used! (Just imagine the mess this would introduce in your application for a specific locale if a translator forgot to add an item or added a new one!)

Other commits are some fixes to not leave empty strings in translations (translator name for instance, you can skip this commit if you wish translators to add their name themselves!).