### PR TITLE
Improvements for the Magisk hide application list

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -55,10 +55,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
         PackageManager packageManager = getActivity().getPackageManager();
 
         mSwipeRefreshLayout.setRefreshing(true);
-        mSwipeRefreshLayout.setOnRefreshListener(() -> {
-            recyclerView.setVisibility(View.GONE);
-            new Async.LoadApps(packageManager).exec();
-        });
+        mSwipeRefreshLayout.setOnRefreshListener(() -> new Async.LoadApps(packageManager).exec());
 
         appAdapter = new ApplicationAdapter(packageManager);
         recyclerView.setAdapter(appAdapter);
@@ -111,7 +108,6 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
         Logger.dev("MagiskHideFragment: UI refresh");
         Async.LoadApps.Result result = (Async.LoadApps.Result) event.getResult();
         appAdapter.setLists(result.listApps, result.hideList);
-        recyclerView.setVisibility(View.VISIBLE);
         mSwipeRefreshLayout.setRefreshing(false);
         if (!TextUtils.isEmpty(lastFilter)) {
             appAdapter.filter(lastFilter);

--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -40,8 +40,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     );
     public static CallbackHandler.Event packageLoadDone = new CallbackHandler.Event();
 
-    private PackageManager packageManager;
-    private ApplicationAdapter appAdapter = new ApplicationAdapter();
+    private ApplicationAdapter appAdapter;
 
     private SearchView.OnQueryTextListener searchListener;
 
@@ -51,7 +50,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
         View view = inflater.inflate(R.layout.magisk_hide_fragment, container, false);
         ButterKnife.bind(this, view);
 
-        packageManager = getActivity().getPackageManager();
+        PackageManager packageManager = getActivity().getPackageManager();
 
         mSwipeRefreshLayout.setRefreshing(true);
         mSwipeRefreshLayout.setOnRefreshListener(() -> {
@@ -59,6 +58,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
             new Async.LoadApps(packageManager).exec();
         });
 
+        appAdapter = new ApplicationAdapter(packageManager);
         recyclerView.setAdapter(appAdapter);
 
         searchListener = new SearchView.OnQueryTextListener() {

--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -43,6 +44,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     private ApplicationAdapter appAdapter;
 
     private SearchView.OnQueryTextListener searchListener;
+    private String lastFilter;
 
     @Nullable
     @Override
@@ -64,12 +66,14 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
         searchListener = new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {
+                lastFilter = query;
                 appAdapter.filter(query);
                 return false;
             }
 
             @Override
             public boolean onQueryTextChange(String newText) {
+                lastFilter = newText;
                 appAdapter.filter(newText);
                 return false;
             }
@@ -109,5 +113,8 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
         appAdapter.setLists(result.listApps, result.hideList);
         recyclerView.setVisibility(View.VISIBLE);
         mSwipeRefreshLayout.setRefreshing(false);
+        if (!TextUtils.isEmpty(lastFilter)) {
+            appAdapter.filter(lastFilter);
+        }
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -41,7 +41,6 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     public static CallbackHandler.Event packageLoadDone = new CallbackHandler.Event();
 
     private PackageManager packageManager;
-    private View mView;
     private ApplicationAdapter appAdapter = new ApplicationAdapter();
 
     private SearchView.OnQueryTextListener searchListener;
@@ -49,8 +48,8 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        mView = inflater.inflate(R.layout.magisk_hide_fragment, container, false);
-        ButterKnife.bind(this, mView);
+        View view = inflater.inflate(R.layout.magisk_hide_fragment, container, false);
+        ButterKnife.bind(this, view);
 
         packageManager = getActivity().getPackageManager();
 
@@ -76,7 +75,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
             }
         };
 
-        return mView;
+        return view;
     }
 
     @Override
@@ -90,7 +89,6 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     public void onResume() {
         super.onResume();
         setHasOptionsMenu(true);
-        mView = this.getView();
         getActivity().setTitle(R.string.magiskhide);
         CallbackHandler.register(packageLoadDone, this);
         if (packageLoadDone.isTriggered) {

--- a/app/src/main/java/com/topjohnwu/magisk/ModulesFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/ModulesFragment.java
@@ -39,13 +39,12 @@ public class ModulesFragment extends Fragment implements CallbackHandler.EventLi
     @BindView(R.id.fab) FloatingActionButton fabio;
 
     private List<Module> listModules = new ArrayList<>();
-    private View mView;
 
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        mView = inflater.inflate(R.layout.modules_fragment, container, false);
-        ButterKnife.bind(this, mView);
+        View view = inflater.inflate(R.layout.modules_fragment, container, false);
+        ButterKnife.bind(this, view);
 
         fabio.setOnClickListener(v -> {
             Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
@@ -74,7 +73,7 @@ public class ModulesFragment extends Fragment implements CallbackHandler.EventLi
             updateUI();
         }
 
-        return mView;
+        return view;
     }
 
     @Override
@@ -96,7 +95,6 @@ public class ModulesFragment extends Fragment implements CallbackHandler.EventLi
     @Override
     public void onResume() {
         super.onResume();
-        mView = this.getView();
         CallbackHandler.register(moduleLoadDone, this);
         getActivity().setTitle(R.string.modules);
     }

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
@@ -1,14 +1,11 @@
 package com.topjohnwu.magisk.adapters;
 
-import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.widget.CheckBox;
 import android.widget.Filter;
 import android.widget.ImageView;
@@ -29,13 +26,13 @@ public class ApplicationAdapter extends RecyclerView.Adapter<ApplicationAdapter.
 
     private List<ApplicationInfo> mOriginalList, mList;
     private List<String> mHideList;
-    private Context context;
     private PackageManager packageManager;
     private ApplicationFilter filter;
 
-    public ApplicationAdapter() {
+    public ApplicationAdapter(PackageManager packageManager) {
         mOriginalList = mList = Collections.emptyList();
         mHideList = Collections.emptyList();
+        this.packageManager = packageManager;
     }
 
     public void setLists(List<ApplicationInfo> listApps, List<String> hideList) {
@@ -47,8 +44,6 @@ public class ApplicationAdapter extends RecyclerView.Adapter<ApplicationAdapter.
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View mView = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_app, parent, false);
-        context = parent.getContext();
-        packageManager = context.getPackageManager();
         ButterKnife.bind(this, mView);
         return new ViewHolder(mView);
     }
@@ -101,12 +96,9 @@ public class ApplicationAdapter extends RecyclerView.Adapter<ApplicationAdapter.
         @BindView(R.id.app_package) TextView appPackage;
         @BindView(R.id.checkbox) CheckBox checkBox;
 
-        public ViewHolder(View itemView) {
+        ViewHolder(View itemView) {
             super(itemView);
-            WindowManager windowmanager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
             ButterKnife.bind(this, itemView);
-            DisplayMetrics dimension = new DisplayMetrics();
-            windowmanager.getDefaultDisplay().getMetrics(dimension);
         }
     }
 

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
@@ -55,15 +55,14 @@ public class ApplicationAdapter extends RecyclerView.Adapter<ApplicationAdapter.
         holder.appIcon.setImageDrawable(info.loadIcon(packageManager));
         holder.appName.setText(info.loadLabel(packageManager));
         holder.appPackage.setText(info.packageName);
-        holder.checkBox.setChecked(mHideList.contains(info.packageName));
 
-        holder.checkBox.setOnClickListener(v -> {
-            CheckBox chkbox = (CheckBox) v;
-            if (chkbox.isChecked()) {
+        holder.checkBox.setOnCheckedChangeListener(null);
+        holder.checkBox.setChecked(mHideList.contains(info.packageName));
+        holder.checkBox.setOnCheckedChangeListener((v, isChecked) -> {
+            if (isChecked) {
                 new Async.MagiskHide().add(info.packageName);
                 mHideList.add(info.packageName);
-            }
-            else {
+            } else {
                 new Async.MagiskHide().rm(info.packageName);
                 mHideList.remove(info.packageName);
             }

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
@@ -55,14 +55,7 @@ public class ApplicationAdapter extends RecyclerView.Adapter<ApplicationAdapter.
         holder.appIcon.setImageDrawable(info.loadIcon(packageManager));
         holder.appName.setText(info.loadLabel(packageManager));
         holder.appPackage.setText(info.packageName);
-        holder.checkBox.setChecked(false);
-
-        for (String hidePackage : mHideList) {
-            if (info.packageName.contains(hidePackage)) {
-                holder.checkBox.setChecked(true);
-                break;
-            }
-        }
+        holder.checkBox.setChecked(mHideList.contains(info.packageName));
 
         holder.checkBox.setOnClickListener(v -> {
             CheckBox chkbox = (CheckBox) v;

--- a/app/src/main/java/com/topjohnwu/magisk/utils/CallbackHandler.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/CallbackHandler.java
@@ -33,10 +33,22 @@ public class CallbackHandler {
     }
 
     public static class Event {
+
         public boolean isTriggered = false;
+        private Object result;
+
         public void trigger() {
+            trigger(null);
+        }
+
+        public void trigger(Object result) {
+            this.result = result;
             isTriggered = true;
             triggerCallback(this);
+        }
+
+        public Object getResult() {
+            return result;
         }
     }
 

--- a/app/src/main/java/com/topjohnwu/magisk/utils/Utils.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/Utils.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Environment;
 import android.support.v4.app.ActivityCompat;
+import android.text.TextUtils;
 import android.util.Base64;
 import android.widget.Toast;
 
@@ -142,6 +143,10 @@ public class Utils {
         } else {
             return new AlertDialog.Builder(context);
         }
+    }
+
+    public static boolean lowercaseContains(CharSequence string, CharSequence nonNullLowercaseSearch) {
+        return !TextUtils.isEmpty(string) && string.toString().toLowerCase().contains(nonNullLowercaseSearch);
     }
 
     public static class ByteArrayInOutStream extends ByteArrayOutputStream {


### PR DESCRIPTION
The current implementation of application list's refreshing and filtering is not thread-safe: adapter's lists are modified from a background thread by AsyncTask's doInBackground() method, this may lead to crashes or unreliable data displayed.
The first commit fixes this behavior, which should improve things regarding issue #41 and pull request #44.

Other commits are fixing/improving the list:
- ~checked state of blacklisted apps is not modifiable,~
- filter is reapplied when the list is reloaded, 
- avoid list blinking when reloading,
- code cleaning to avoid unnecessary class fields...