### PR TITLE
Various fixes and code cleaning for repo and module lists

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
@@ -49,67 +49,44 @@ public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHold
 
         holder.checkBox.setOnCheckedChangeListener(null);
         holder.checkBox.setChecked(module.isEnabled());
-        holder.checkBox.setOnCheckedChangeListener((v, isChecked) -> {
-            if (isChecked) {
-                new Async.RootTask<Void, Void, Void>() {
-                    @Override
-                    protected Void doInBackground(Void... voids) {
-                        module.removeDisableFile();
-                        return null;
-                    }
-
-                    @Override
-                    protected void onPostExecute(Void v) {
-                        Snackbar.make(holder.title, R.string.disable_file_removed, Snackbar.LENGTH_SHORT).show();
-                    }
-                }.exec();
-            } else {
-                new Async.RootTask<Void, Void, Void>() {
-                    @Override
-                    protected Void doInBackground(Void... voids) {
-                        module.createDisableFile();
-                        return null;
-                    }
-
-                    @Override
-                    protected void onPostExecute(Void v) {
-                        Snackbar.make(holder.title, R.string.disable_file_created, Snackbar.LENGTH_SHORT).show();
-                    }
-                }.exec();
+        holder.checkBox.setOnCheckedChangeListener((v, isChecked) -> new Async.RootTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                if (isChecked) {
+                    module.removeDisableFile();
+                } else {
+                    module.createDisableFile();
+                }
+                return null;
             }
-        });
 
-        holder.delete.setOnClickListener(v -> {
-            if (module.willBeRemoved()) {
-                new Async.RootTask<Void, Void, Void>() {
-                    @Override
-                    protected Void doInBackground(Void... voids) {
-                        module.deleteRemoveFile();
-                        return null;
-                    }
-
-                    @Override
-                    protected void onPostExecute(Void v) {
-                        Snackbar.make(holder.title, R.string.remove_file_deleted, Snackbar.LENGTH_SHORT).show();
-                        updateDeleteButton(holder, module);
-                    }
-                }.exec();
-            } else {
-                new Async.RootTask<Void, Void, Void>() {
-                    @Override
-                    protected Void doInBackground(Void... voids) {
-                        module.createRemoveFile();
-                        return null;
-                    }
-
-                    @Override
-                    protected void onPostExecute(Void v) {
-                        Snackbar.make(holder.title, R.string.remove_file_created, Snackbar.LENGTH_SHORT).show();
-                        updateDeleteButton(holder, module);
-                    }
-                }.exec();
+            @Override
+            protected void onPostExecute(Void v) {
+                int title = isChecked ? R.string.disable_file_removed : R.string.disable_file_created;
+                Snackbar.make(holder.title, title, Snackbar.LENGTH_SHORT).show();
             }
-        });
+        }.exec());
+
+        holder.delete.setOnClickListener(v -> new Async.RootTask<Void, Void, Void>() {
+            private final boolean removed = module.willBeRemoved();
+
+            @Override
+            protected Void doInBackground(Void... voids) {
+                if (removed) {
+                    module.deleteRemoveFile();
+                } else {
+                    module.createRemoveFile();
+                }
+                return null;
+            }
+
+            @Override
+            protected void onPostExecute(Void v) {
+                int title = removed ? R.string.remove_file_deleted : R.string.remove_file_created;
+                Snackbar.make(holder.title, title, Snackbar.LENGTH_SHORT).show();
+                updateDeleteButton(holder, module);
+            }
+        }.exec());
 
         if (module.isUpdated()) {
             holder.notice.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
@@ -3,6 +3,7 @@ package com.topjohnwu.magisk.adapters;
 import android.content.Context;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,18 +42,10 @@ public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHold
         final Module module = mList.get(position);
 
         holder.title.setText(module.getName());
+        holder.versionName.setText(module.getVersion());
         String author = module.getAuthor();
-        String versionName = module.getVersion();
-        String description = module.getDescription();
-        if (versionName != null) {
-            holder.versionName.setText(versionName);
-        }
-        if (author != null) {
-            holder.author.setText(context.getString(R.string.author, author));
-        }
-        if (description != null) {
-            holder.description.setText(description);
-        }
+        holder.author.setText(TextUtils.isEmpty(author) ? null : context.getString(R.string.author, author));
+        holder.description.setText(module.getDescription());
 
         holder.checkBox.setChecked(module.isEnabled());
         holder.checkBox.setOnClickListener((v) -> {

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
@@ -47,10 +47,10 @@ public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHold
         holder.author.setText(TextUtils.isEmpty(author) ? null : context.getString(R.string.author, author));
         holder.description.setText(module.getDescription());
 
+        holder.checkBox.setOnCheckedChangeListener(null);
         holder.checkBox.setChecked(module.isEnabled());
-        holder.checkBox.setOnClickListener((v) -> {
-            CheckBox checkBox = (CheckBox) v;
-            if (checkBox.isChecked()) {
+        holder.checkBox.setOnCheckedChangeListener((v, isChecked) -> {
+            if (isChecked) {
                 new Async.RootTask<Void, Void, Void>() {
                     @Override
                     protected Void doInBackground(Void... voids) {

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
@@ -3,11 +3,9 @@ package com.topjohnwu.magisk.adapters;
 import android.content.Context;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.RecyclerView;
-import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -25,7 +23,6 @@ import butterknife.ButterKnife;
 public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHolder> {
 
     private final List<Module> mList;
-    private Context context;
 
     public ModulesAdapter(List<Module> list) {
         mList = list;
@@ -34,14 +31,15 @@ public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHold
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_module, parent, false);
-        context = parent.getContext();
         ButterKnife.bind(this, view);
         return new ViewHolder(view);
     }
 
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
+        Context context = holder.itemView.getContext();
         final Module module = mList.get(position);
+
         holder.title.setText(module.getName());
         String author = module.getAuthor();
         String versionName = module.getVersion();
@@ -144,7 +142,7 @@ public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHold
         return mList.size();
     }
 
-    class ViewHolder extends RecyclerView.ViewHolder {
+    static class ViewHolder extends RecyclerView.ViewHolder {
 
         @BindView(R.id.title) TextView title;
         @BindView(R.id.version_name) TextView versionName;
@@ -154,12 +152,9 @@ public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHold
         @BindView(R.id.author) TextView author;
         @BindView(R.id.delete) ImageView delete;
 
-        public ViewHolder(View itemView) {
+        ViewHolder(View itemView) {
             super(itemView);
-            WindowManager windowmanager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
             ButterKnife.bind(this, itemView);
-            DisplayMetrics dimension = new DisplayMetrics();
-            windowmanager.getDefaultDisplay().getMetrics(dimension);
 
             if (!Shell.rootAccess()) {
                 checkBox.setEnabled(false);

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
@@ -8,12 +8,10 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
-import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
-import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -34,9 +32,6 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
 
     private List<Repo> mUpdateRepos, mInstalledRepos, mOthersRepos;
     private HashSet<Repo> expandList = new HashSet<>();
-    private Context mContext;
-
-    private int expandHeight = 0;
 
     public ReposAdapter(List<Repo> update, List<Repo> installed, List<Repo> others) {
         mUpdateRepos = update;
@@ -48,13 +43,12 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_repo, parent, false);
         ButterKnife.bind(this, v);
-        mContext = parent.getContext();
-
         return new ViewHolder(v);
     }
 
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
+        Context context = holder.itemView.getContext();
         final Repo repo;
         if (position >= mUpdateRepos.size()) {
             position -= mUpdateRepos.size();
@@ -75,7 +69,7 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
             holder.versionName.setText(versionName);
         }
         if (author != null) {
-            holder.author.setText(mContext.getString(R.string.author, author));
+            holder.author.setText(context.getString(R.string.author, author));
         }
         if (description != null) {
             holder.description.setText(description);
@@ -94,17 +88,17 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
         });
         holder.changeLog.setOnClickListener(view -> {
             if (!TextUtils.isEmpty(repo.getLogUrl())) {
-                new WebWindow(mContext.getString(R.string.changelog), repo.getLogUrl(), mContext);
+                new WebWindow(context.getString(R.string.changelog), repo.getLogUrl(), context);
             }
         });
         holder.updateImage.setOnClickListener(view -> {
             String filename = repo.getName() + "-" + repo.getVersion() + ".zip";
-            Utils.getAlertDialogBuilder(mContext)
-                    .setTitle(mContext.getString(R.string.repo_install_title, repo.getName()))
-                    .setMessage(mContext.getString(R.string.repo_install_msg, filename))
+            Utils.getAlertDialogBuilder(context)
+                    .setTitle(context.getString(R.string.repo_install_title, repo.getName()))
+                    .setMessage(context.getString(R.string.repo_install_msg, filename))
                     .setCancelable(true)
                     .setPositiveButton(R.string.download_install, (dialogInterface, i) -> Utils.dlAndReceive(
-                            mContext,
+                            context,
                             new RepoDlReceiver(),
                             repo.getZipUrl(),
                             Utils.getLegalFilename(filename)))
@@ -113,12 +107,12 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
         });
         holder.authorLink.setOnClickListener(view -> {
             if (!TextUtils.isEmpty(repo.getDonateUrl())) {
-                mContext.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(repo.getDonateUrl())));
+                context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(repo.getDonateUrl())));
             }
         });
         holder.supportLink.setOnClickListener(view -> {
             if (!TextUtils.isEmpty(repo.getSupportUrl())) {
-                mContext.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(repo.getSupportUrl())));
+                context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(repo.getSupportUrl())));
             }
         });
     }
@@ -128,7 +122,7 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
         return mUpdateRepos.size() + mInstalledRepos.size() + mOthersRepos.size();
     }
 
-    class ViewHolder extends RecyclerView.ViewHolder {
+    static class ViewHolder extends RecyclerView.ViewHolder {
 
         @BindView(R.id.title) TextView title;
         @BindView(R.id.version_name) TextView versionName;
@@ -143,13 +137,11 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
         private ValueAnimator mAnimator;
         private ObjectAnimator animY2;
         private boolean mExpanded = false;
+        private static int expandHeight = 0;
 
-        public ViewHolder(View itemView) {
+        ViewHolder(View itemView) {
             super(itemView);
-            WindowManager windowmanager = (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
             ButterKnife.bind(this, itemView);
-            DisplayMetrics dimension = new DisplayMetrics();
-            windowmanager.getDefaultDisplay().getMetrics(dimension);
             expandLayout.getViewTreeObserver().addOnPreDrawListener(
                     new ViewTreeObserver.OnPreDrawListener() {
 

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -92,7 +93,7 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
             }
         });
         holder.changeLog.setOnClickListener(view -> {
-            if (!repo.getLogUrl().isEmpty()) {
+            if (!TextUtils.isEmpty(repo.getLogUrl())) {
                 new WebWindow(mContext.getString(R.string.changelog), repo.getLogUrl(), mContext);
             }
         });
@@ -111,12 +112,12 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
                     .show();
         });
         holder.authorLink.setOnClickListener(view -> {
-            if (!repo.getDonateUrl().isEmpty()) {
+            if (!TextUtils.isEmpty(repo.getDonateUrl())) {
                 mContext.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(repo.getDonateUrl())));
             }
         });
         holder.supportLink.setOnClickListener(view -> {
-            if (!repo.getSupportUrl().isEmpty()) {
+            if (!TextUtils.isEmpty(repo.getSupportUrl())) {
                 mContext.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(repo.getSupportUrl())));
             }
         });

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
@@ -49,18 +49,8 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
         Context context = holder.itemView.getContext();
-        final Repo repo;
-        if (position >= mUpdateRepos.size()) {
-            position -= mUpdateRepos.size();
-            if (position >= mInstalledRepos.size()) {
-                position -= mInstalledRepos.size();
-                repo = mOthersRepos.get(position);
-            } else {
-                repo = mInstalledRepos.get(position);
-            }
-        } else {
-            repo = mUpdateRepos.get(position);
-        }
+        Repo repo = getItem(position);
+
         holder.title.setText(repo.getName());
         String author = repo.getAuthor();
         String versionName = repo.getVersion();
@@ -120,6 +110,20 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
     @Override
     public int getItemCount() {
         return mUpdateRepos.size() + mInstalledRepos.size() + mOthersRepos.size();
+    }
+
+    private Repo getItem(int position) {
+        if (position >= mUpdateRepos.size()) {
+            position -= mUpdateRepos.size();
+            if (position >= mInstalledRepos.size()) {
+                position -= mInstalledRepos.size();
+                return mOthersRepos.get(position);
+            } else {
+                return mInstalledRepos.get(position);
+            }
+        } else {
+            return mUpdateRepos.get(position);
+        }
     }
 
     static class ViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
@@ -52,18 +52,10 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
         Repo repo = getItem(position);
 
         holder.title.setText(repo.getName());
+        holder.versionName.setText(repo.getVersion());
         String author = repo.getAuthor();
-        String versionName = repo.getVersion();
-        String description = repo.getDescription();
-        if (versionName != null) {
-            holder.versionName.setText(versionName);
-        }
-        if (author != null) {
-            holder.author.setText(context.getString(R.string.author, author));
-        }
-        if (description != null) {
-            holder.description.setText(description);
-        }
+        holder.author.setText(TextUtils.isEmpty(author) ? null : context.getString(R.string.author, author));
+        holder.description.setText(repo.getDescription());
 
         holder.setExpanded(expandList.contains(repo));
 


### PR DESCRIPTION
Almost like PR #49 (except the refactoring of loading and filtering tasks), this fixes some issues in the repository list and the module list:
- avoid storing context instance in adapters to minimize leaks,
- fix inconsistent information displayed in some text fields,
- ~fix wrong string checked before use,~
- NullPointerException-proofing,
- clean cumbersome parts of the code...

There is still a lot of work to do to make lists reloading and filtering thread-safe (and thus avoiding possible crashes or inconsistent data), but this will be for another pull request.