### PR TITLE
Code cleaning and event listener registering improvements

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/AboutActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/AboutActivity.java
@@ -63,13 +63,11 @@ public class AboutActivity extends AppCompatActivity {
         appVersionInfo.setSummary(BuildConfig.VERSION_NAME);
 
         String changes = null;
-        try {
-            InputStream is = getAssets().open("changelog.html");
+        try (InputStream is = getAssets().open("changelog.html")) {
             int size = is.available();
 
             byte[] buffer = new byte[size];
             is.read(buffer);
-            is.close();
 
             changes = new String(buffer);
         } catch (IOException ignored) {

--- a/app/src/main/java/com/topjohnwu/magisk/InstallFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/InstallFragment.java
@@ -98,15 +98,15 @@ public class InstallFragment extends Fragment implements CallbackHandler.EventLi
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
+    public void onStart() {
+        super.onStart();
         getActivity().setTitle(R.string.install);
         CallbackHandler.register(blockDetectionDone, this);
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onStop() {
         CallbackHandler.unRegister(blockDetectionDone, this);
+        super.onStop();
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/InstallFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/InstallFragment.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class InstallFragment extends Fragment implements CallbackHandler.EventListener {
 
@@ -32,6 +33,7 @@ public class InstallFragment extends Fragment implements CallbackHandler.EventLi
     public static List<String> blockList;
     public static String bootBlock = null;
 
+    private Unbinder unbinder;
     @BindView(R.id.current_version_title) TextView currentVersionTitle;
     @BindView(R.id.install_title) TextView installTitle;
     @BindView(R.id.block_spinner) Spinner spinner;
@@ -44,7 +46,7 @@ public class InstallFragment extends Fragment implements CallbackHandler.EventLi
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.install_fragment, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         detectButton.setOnClickListener(v1 -> toAutoDetect());
         currentVersionTitle.setText(getString(R.string.current_magisk_title, StatusFragment.magiskVersionString));
         installTitle.setText(getString(R.string.install_magisk_title, StatusFragment.remoteMagiskVersion));
@@ -108,5 +110,11 @@ public class InstallFragment extends Fragment implements CallbackHandler.EventLi
     public void onStop() {
         CallbackHandler.unRegister(blockDetectionDone, this);
         super.onStop();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
@@ -38,11 +38,13 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class LogFragment extends Fragment {
 
     private static final String MAGISK_LOG = "/cache/magisk.log";
 
+    private Unbinder unbinder;
     @BindView(R.id.txtLog) TextView txtLog;
     @BindView(R.id.svLog) ScrollView svLog;
     @BindView(R.id.hsvLog) HorizontalScrollView hsvLog;
@@ -61,7 +63,7 @@ public class LogFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.log_fragment, container, false);
-        ButterKnife.bind(this, view);
+        unbinder = ButterKnife.bind(this, view);
 
         txtLog.setTextIsSelectable(true);
 
@@ -80,6 +82,12 @@ public class LogFragment extends Fragment {
     public void onResume() {
         super.onResume();
         new LogManager().read();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 
     @Override

--- a/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
@@ -71,10 +71,15 @@ public class LogFragment extends Fragment {
     }
 
     @Override
+    public void onStart() {
+        super.onStart();
+        getActivity().setTitle(R.string.log);
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
         new LogManager().read();
-        getActivity().setTitle(R.string.log);
     }
 
     @Override

--- a/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
 import android.view.LayoutInflater;
@@ -51,6 +52,13 @@ public class LogFragment extends Fragment {
     private MenuItem mClickedMenuItem;
 
     @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
+    @Nullable
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.log_fragment, container, false);
         ButterKnife.bind(this, view);
@@ -65,7 +73,6 @@ public class LogFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        setHasOptionsMenu(true);
         new LogManager().read();
         getActivity().setTitle(R.string.log);
     }

--- a/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/LogFragment.java
@@ -182,14 +182,10 @@ public class LogFragment extends Fragment {
 
                     List<String> in = Utils.readFile(MAGISK_LOG);
 
-                    try {
-                        FileWriter out = new FileWriter(targetFile);
+                    try (FileWriter out = new FileWriter(targetFile)) {
                         for (String line : in) {
                             out.write(line + "\n");
                         }
-                        out.close();
-
-
                         return true;
                     } catch (IOException e) {
                         e.printStackTrace();

--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -39,7 +39,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
             "com.google.android.apps.walletnfcrel",
             "com.nianticlabs.pokemongo"
     );
-    public static CallbackHandler.Event packageLoadDone = new CallbackHandler.Event();
+    public static final CallbackHandler.Event packageLoadDone = new CallbackHandler.Event();
 
     private ApplicationAdapter appAdapter;
 

--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -25,9 +25,11 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class MagiskHideFragment extends Fragment implements CallbackHandler.EventListener {
 
+    private Unbinder unbinder;
     @BindView(R.id.swipeRefreshLayout) SwipeRefreshLayout mSwipeRefreshLayout;
     @BindView(R.id.recyclerView) RecyclerView recyclerView;
 
@@ -56,7 +58,7 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.magisk_hide_fragment, container, false);
-        ButterKnife.bind(this, view);
+        unbinder = ButterKnife.bind(this, view);
 
         PackageManager packageManager = getActivity().getPackageManager();
 
@@ -106,6 +108,12 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     public void onStop() {
         CallbackHandler.unRegister(packageLoadDone, this);
         super.onStop();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 
     @Override

--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -93,8 +93,8 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
+    public void onStart() {
+        super.onStart();
         getActivity().setTitle(R.string.magiskhide);
         CallbackHandler.register(packageLoadDone, this);
         if (packageLoadDone.isTriggered) {
@@ -103,9 +103,9 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     }
 
     @Override
-    public void onPause() {
-        super.onPause();
+    public void onStop() {
         CallbackHandler.unRegister(packageLoadDone, this);
+        super.onStop();
     }
 
     @Override

--- a/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MagiskHideFragment.java
@@ -46,6 +46,12 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     private SearchView.OnQueryTextListener searchListener;
     private String lastFilter;
 
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -89,7 +95,6 @@ public class MagiskHideFragment extends Fragment implements CallbackHandler.Even
     @Override
     public void onResume() {
         super.onResume();
-        setHasOptionsMenu(true);
         getActivity().setTitle(R.string.magiskhide);
         CallbackHandler.register(packageLoadDone, this);
         if (packageLoadDone.isTriggered) {

--- a/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
-import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.ActivityCompat;
@@ -44,7 +43,6 @@ public class MainActivity extends AppCompatActivity
     @BindView(R.id.drawer_layout) DrawerLayout drawer;
     @BindView(R.id.nav_view) public NavigationView navigationView;
 
-    @IdRes
     private int mSelectedId = R.id.status;
 
     @Override
@@ -82,13 +80,11 @@ public class MainActivity extends AppCompatActivity
         drawer.addDrawerListener(toggle);
         toggle.syncState();
 
-        //noinspection ResourceType
-        mSelectedId = savedInstanceState == null ? mSelectedId : savedInstanceState.getInt(SELECTED_ITEM_ID);
-        navigationView.setCheckedItem(mSelectedId);
-
         if (savedInstanceState == null) {
-            mDrawerHandler.removeCallbacksAndMessages(null);
-            mDrawerHandler.postDelayed(() -> navigate(mSelectedId), 250);
+            navigate(mSelectedId, true);
+            navigationView.setCheckedItem(mSelectedId);
+        } else {
+            mSelectedId = savedInstanceState.getInt(SELECTED_ITEM_ID);
         }
 
         navigationView.setNavigationItemSelectedListener(this);
@@ -136,7 +132,7 @@ public class MainActivity extends AppCompatActivity
     public boolean onNavigationItemSelected(@NonNull final MenuItem menuItem) {
         mSelectedId = menuItem.getItemId();
         mDrawerHandler.removeCallbacksAndMessages(null);
-        mDrawerHandler.postDelayed(() -> navigate(menuItem.getItemId()), 250);
+        mDrawerHandler.postDelayed(() -> navigate(menuItem.getItemId(), false), 250);
         drawer.closeDrawer(GravityCompat.START);
         return true;
     }
@@ -164,48 +160,40 @@ public class MainActivity extends AppCompatActivity
         menu.findItem(R.id.install).setVisible(Shell.rootAccess());
     }
 
-    public void navigate(final int itemId) {
-        Fragment navFragment = null;
-        String tag = "";
+    public void navigate(int itemId, boolean now) {
         switch (itemId) {
             case R.id.status:
-                tag = "status";
-                navFragment = new StatusFragment();
+                displayFragment(new StatusFragment(), "status", now);
                 break;
             case R.id.install:
-                tag = "install";
-                navFragment = new InstallFragment();
+                displayFragment(new InstallFragment(), "install", now);
                 break;
             case R.id.modules:
-                tag = "modules";
-                navFragment = new ModulesFragment();
+                displayFragment(new ModulesFragment(), "modules", now);
                 break;
             case R.id.downloads:
-                tag = "downloads";
-                navFragment = new ReposFragment();
+                displayFragment(new ReposFragment(), "downloads", now);
                 break;
             case R.id.magiskhide:
-                tag = "magiskhide";
-                navFragment = new MagiskHideFragment();
+                displayFragment(new MagiskHideFragment(), "magiskhide", now);
                 break;
             case R.id.log:
-                tag = "log";
-                navFragment = new LogFragment();
+                displayFragment(new LogFragment(), "log", now);
                 break;
             case R.id.settings:
                 startActivity(new Intent(this, SettingsActivity.class));
                 break;
             case R.id.app_about:
                 startActivity(new Intent(this, AboutActivity.class));
-                return;
+                break;
         }
+    }
 
-        if (navFragment != null) {
-            FragmentTransaction transaction = getFragmentManager().beginTransaction();
+    private void displayFragment(@NonNull Fragment navFragment, String tag, boolean now) {
+        FragmentTransaction transaction = getFragmentManager().beginTransaction();
+        if (!now) {
             transaction.setCustomAnimations(android.R.animator.fade_in, android.R.animator.fade_out);
-            try {
-                transaction.replace(R.id.content_frame, navFragment, tag).commit();
-            } catch (IllegalStateException ignored) {}
         }
+        transaction.replace(R.id.content_frame, navFragment, tag).commit();
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
@@ -35,7 +35,7 @@ public class MainActivity extends AppCompatActivity
 
     private static final String SELECTED_ITEM_ID = "SELECTED_ITEM_ID";
 
-    public static CallbackHandler.Event recreate = new CallbackHandler.Event();
+    public static final CallbackHandler.Event recreate = new CallbackHandler.Event();
 
     private final Handler mDrawerHandler = new Handler();
     private SharedPreferences prefs;

--- a/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
@@ -92,13 +92,13 @@ public class MainActivity extends AppCompatActivity
         }
 
         navigationView.setNavigationItemSelectedListener(this);
+        CallbackHandler.register(recreate, this);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
         CallbackHandler.register(StatusFragment.updateCheckDone, this);
-        CallbackHandler.register(recreate, this);
         if (StatusFragment.updateCheckDone.isTriggered) {
             onTrigger(StatusFragment.updateCheckDone);
         }
@@ -107,14 +107,14 @@ public class MainActivity extends AppCompatActivity
 
     @Override
     protected void onPause() {
-        super.onPause();
         CallbackHandler.unRegister(StatusFragment.updateCheckDone, this);
+        super.onPause();
     }
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         CallbackHandler.unRegister(recreate, this);
+        super.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/com/topjohnwu/magisk/ModulesFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/ModulesFragment.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class ModulesFragment extends Fragment implements CallbackHandler.EventListener {
 
@@ -33,6 +34,7 @@ public class ModulesFragment extends Fragment implements CallbackHandler.EventLi
 
     private static final int FETCH_ZIP_CODE = 2;
 
+    private Unbinder unbinder;
     @BindView(R.id.swipeRefreshLayout) SwipeRefreshLayout mSwipeRefreshLayout;
     @BindView(R.id.recyclerView) RecyclerView recyclerView;
     @BindView(R.id.empty_rv) TextView emptyTv;
@@ -44,7 +46,7 @@ public class ModulesFragment extends Fragment implements CallbackHandler.EventLi
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.modules_fragment, container, false);
-        ButterKnife.bind(this, view);
+        unbinder = ButterKnife.bind(this, view);
 
         fabio.setOnClickListener(v -> {
             Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
@@ -103,6 +105,12 @@ public class ModulesFragment extends Fragment implements CallbackHandler.EventLi
     public void onStop() {
         CallbackHandler.unRegister(moduleLoadDone, this);
         super.onStop();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 
     private void updateUI() {

--- a/app/src/main/java/com/topjohnwu/magisk/ModulesFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/ModulesFragment.java
@@ -93,16 +93,16 @@ public class ModulesFragment extends Fragment implements CallbackHandler.EventLi
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
+    public void onStart() {
+        super.onStart();
         CallbackHandler.register(moduleLoadDone, this);
         getActivity().setTitle(R.string.modules);
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onStop() {
         CallbackHandler.unRegister(moduleLoadDone, this);
+        super.onStop();
     }
 
     private void updateUI() {

--- a/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
@@ -27,11 +27,13 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class ReposFragment extends Fragment implements CallbackHandler.EventListener {
 
     public static final CallbackHandler.Event repoLoadDone = new CallbackHandler.Event();
 
+    private Unbinder unbinder;
     @BindView(R.id.recyclerView) RecyclerView recyclerView;
     @BindView(R.id.empty_rv) TextView emptyTv;
     @BindView(R.id.swipeRefreshLayout) SwipeRefreshLayout mSwipeRefreshLayout;
@@ -57,8 +59,7 @@ public class ReposFragment extends Fragment implements CallbackHandler.EventList
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.repos_fragment, container, false);
-
-        ButterKnife.bind(this, view);
+        unbinder = ButterKnife.bind(this, view);
 
         mSectionedAdapter = new
                 SimpleSectionedRecyclerViewAdapter(getActivity(), R.layout.section,
@@ -119,6 +120,12 @@ public class ReposFragment extends Fragment implements CallbackHandler.EventList
     public void onStop() {
         CallbackHandler.unRegister(repoLoadDone, this);
         super.onStop();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 
     private void reloadRepos() {

--- a/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
@@ -47,8 +47,13 @@ public class ReposFragment extends Fragment implements CallbackHandler.EventList
 
     private SearchView.OnQueryTextListener searchListener;
 
-    @Nullable
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
 
+    @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.repos_fragment, container, false);
@@ -106,7 +111,6 @@ public class ReposFragment extends Fragment implements CallbackHandler.EventList
     @Override
     public void onResume() {
         super.onResume();
-        setHasOptionsMenu(true);
         CallbackHandler.register(repoLoadDone, this);
         getActivity().setTitle(R.string.downloads);
     }

--- a/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
@@ -109,16 +109,16 @@ public class ReposFragment extends Fragment implements CallbackHandler.EventList
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
+    public void onStart() {
+        super.onStart();
         CallbackHandler.register(repoLoadDone, this);
         getActivity().setTitle(R.string.downloads);
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onStop() {
         CallbackHandler.unRegister(repoLoadDone, this);
+        super.onStop();
     }
 
     private void reloadRepos() {

--- a/app/src/main/java/com/topjohnwu/magisk/SettingsActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/SettingsActivity.java
@@ -131,8 +131,8 @@ public class SettingsActivity extends AppCompatActivity {
 
         @Override
         public void onDestroy() {
-            super.onDestroy();
             prefs.unregisterOnSharedPreferenceChangeListener(this);
+            super.onDestroy();
         }
 
         @Override

--- a/app/src/main/java/com/topjohnwu/magisk/StatusFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/StatusFragment.java
@@ -26,6 +26,7 @@ import java.util.List;
 import butterknife.BindColor;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class StatusFragment extends Fragment implements CallbackHandler.EventListener {
 
@@ -38,6 +39,7 @@ public class StatusFragment extends Fragment implements CallbackHandler.EventLis
     public static final CallbackHandler.Event updateCheckDone = new CallbackHandler.Event();
     public static final CallbackHandler.Event safetyNetDone = new CallbackHandler.Event();
 
+    private Unbinder unbinder;
     @BindView(R.id.swipeRefreshLayout) SwipeRefreshLayout mSwipeRefreshLayout;
 
     @BindView(R.id.magisk_status_container) View magiskStatusContainer;
@@ -74,7 +76,7 @@ public class StatusFragment extends Fragment implements CallbackHandler.EventLis
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.status_fragment, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
 
         defaultColor = magiskUpdateText.getCurrentTextColor();
 
@@ -159,6 +161,12 @@ public class StatusFragment extends Fragment implements CallbackHandler.EventLis
         CallbackHandler.unRegister(updateCheckDone, this);
         CallbackHandler.unRegister(safetyNetDone, this);
         super.onStop();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 
     private static void checkMagiskInfo() {

--- a/app/src/main/java/com/topjohnwu/magisk/StatusFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/StatusFragment.java
@@ -141,8 +141,8 @@ public class StatusFragment extends Fragment implements CallbackHandler.EventLis
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
+    public void onStart() {
+        super.onStart();
         CallbackHandler.register(updateCheckDone, this);
         CallbackHandler.register(safetyNetDone, this);
         if (updateCheckDone.isTriggered) {
@@ -155,10 +155,10 @@ public class StatusFragment extends Fragment implements CallbackHandler.EventLis
     }
 
     @Override
-    public void onPause() {
-        super.onPause();
+    public void onStop() {
         CallbackHandler.unRegister(updateCheckDone, this);
         CallbackHandler.unRegister(safetyNetDone, this);
+        super.onStop();
     }
 
     private static void checkMagiskInfo() {

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ApplicationAdapter.java
@@ -44,7 +44,6 @@ public class ApplicationAdapter extends RecyclerView.Adapter<ApplicationAdapter.
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View mView = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_app, parent, false);
-        ButterKnife.bind(this, mView);
         return new ViewHolder(mView);
     }
 

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ModulesAdapter.java
@@ -32,7 +32,6 @@ public class ModulesAdapter extends RecyclerView.Adapter<ModulesAdapter.ViewHold
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_module, parent, false);
-        ButterKnife.bind(this, view);
         return new ViewHolder(view);
     }
 

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
@@ -42,7 +42,6 @@ public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> 
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_repo, parent, false);
-        ButterKnife.bind(this, v);
         return new ViewHolder(v);
     }
 

--- a/app/src/main/java/com/topjohnwu/magisk/receivers/RepoDlReceiver.java
+++ b/app/src/main/java/com/topjohnwu/magisk/receivers/RepoDlReceiver.java
@@ -33,9 +33,9 @@ public class RepoDlReceiver extends DownloadReceiver {
                 ZipUtils.signZip(mContext, buffer.getInputStream(), buffer, true);
 
                 // Write it back to the downloaded zip
-                OutputStream out = mContext.getContentResolver().openOutputStream(mUri);
-                buffer.writeTo(out);
-                out.close();
+                try (OutputStream out = mContext.getContentResolver().openOutputStream(mUri)) {
+                    buffer.writeTo(out);
+                }
             }
         }.exec();
     }

--- a/app/src/main/java/com/topjohnwu/magisk/utils/Async.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/Async.java
@@ -194,21 +194,21 @@ public class Async {
 
         protected void copyToCache() throws Throwable {
             publishProgress(mContext.getString(R.string.copying_msg));
-            try {
-                InputStream in = mContext.getContentResolver().openInputStream(mUri);
-                mCachedFile = new File(mContext.getCacheDir().getAbsolutePath() + "/install.zip");
-                if (mCachedFile.exists() && !mCachedFile.delete()) {
-                    throw new IOException();
-                }
-                OutputStream outputStream = new FileOutputStream(mCachedFile);
+            mCachedFile = new File(mContext.getCacheDir().getAbsolutePath() + "/install.zip");
+            if (mCachedFile.exists() && !mCachedFile.delete()) {
+                Log.e(Logger.TAG, "FlashZip: Error while deleting already existing file");
+                throw new IOException();
+            }
+            try (
+                    InputStream in = mContext.getContentResolver().openInputStream(mUri);
+                    OutputStream outputStream = new FileOutputStream(mCachedFile)
+            ) {
                 byte buffer[] = new byte[1024];
                 int length;
                 while ((length = in.read(buffer)) > 0) {
                     outputStream.write(buffer, 0, length);
                 }
-                outputStream.close();
                 Logger.dev("FlashZip: File created successfully - " + mCachedFile.getPath());
-                in.close();
             } catch (FileNotFoundException e) {
                 Log.e(Logger.TAG, "FlashZip: Invalid Uri");
                 throw e;

--- a/app/src/main/java/com/topjohnwu/magisk/utils/ModuleHelper.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/ModuleHelper.java
@@ -168,7 +168,7 @@ public class ModuleHelper {
         }
     }
 
-    private static class ValueSortedMap<K, V extends Comparable > extends HashMap<K, V> {
+    private static class ValueSortedMap<K, V extends Comparable<? super V>> extends HashMap<K, V> {
 
         private List<V> sorted = new ArrayList<>();
 

--- a/app/src/main/java/com/topjohnwu/magisk/utils/ZipUtils.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/ZipUtils.java
@@ -125,17 +125,16 @@ public class ZipUtils {
     }
 
     public static void unzip(File file, File folder, String path) {
-        try {
-            int count;
-            FileOutputStream out;
-            File dest;
-            InputStream is;
-            JarEntry entry;
-            byte data[] = new byte[4096];
-            JarFile zipfile = new JarFile(file);
-            Enumeration e = zipfile.entries();
+        int count;
+        FileOutputStream out;
+        File dest;
+        InputStream is;
+        JarEntry entry;
+        byte data[] = new byte[4096];
+        try (JarFile zipfile = new JarFile(file)) {
+            Enumeration<JarEntry> e = zipfile.entries();
             while(e.hasMoreElements()) {
-                entry = (JarEntry) e.nextElement();
+                entry = e.nextElement();
                 if (!entry.getName().contains(path)
                         || entry.getName().charAt(entry.getName().length() - 1) == '/') {
                     // Ignore directories, only create files
@@ -518,9 +517,10 @@ public class ZipUtils {
                         .build(signer, publicKey));
         gen.addCertificates(certs);
         CMSSignedData sigData = gen.generate(data, false);
-        ASN1InputStream asn1 = new ASN1InputStream(sigData.getEncoded());
-        DEROutputStream dos = new DEROutputStream(out);
-        dos.writeObject(asn1.readObject());
+        try (ASN1InputStream asn1 = new ASN1InputStream(sigData.getEncoded())) {
+            DEROutputStream dos = new DEROutputStream(out);
+            dos.writeObject(asn1.readObject());
+        }
     }
     /**
      * Copy all the files in a manifest from input to output.  We set


### PR DESCRIPTION
Various little improvements that make the code cleaner.
May prevent issues with non-closed IO streams (use of try-with-resource), as well as callback events running even if the fragment is being destroyed (see comments in the commit), or bound views kept in memory after the fragment is destroyed (use of Butterknife's unbinder).