### PR TITLE
Manifold improvements

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,5 +1,0 @@
-cmake_minimum_required(VERSION 3.6)
-add_library(zipadjust SHARED src/main/jni/zipadjust.c)
-find_library(libz z)
-find_library(liblog log)
-target_link_libraries(zipadjust ${libz} ${liblog})

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
     }
     externalNativeBuild {
         cmake {
-            path 'CMakeLists.txt'
+            path 'src/main/jni/CMakeLists.txt'
         }
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
@@ -13,7 +13,6 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.ActivityCompat;
-import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
@@ -118,8 +117,8 @@ public class MainActivity extends AppCompatActivity
 
     @Override
     public void onBackPressed() {
-        if (drawer.isDrawerOpen(GravityCompat.START)) {
-            drawer.closeDrawer(GravityCompat.START);
+        if (drawer.isDrawerOpen(navigationView)) {
+            drawer.closeDrawer(navigationView);
         } else {
             finish();
         }
@@ -130,7 +129,7 @@ public class MainActivity extends AppCompatActivity
         mSelectedId = menuItem.getItemId();
         mDrawerHandler.removeCallbacksAndMessages(null);
         mDrawerHandler.postDelayed(() -> navigate(menuItem.getItemId(), false), 250);
-        drawer.closeDrawer(GravityCompat.START);
+        drawer.closeDrawer(navigationView);
         return true;
     }
 

--- a/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
+++ b/app/src/main/java/com/topjohnwu/magisk/ReposFragment.java
@@ -59,8 +59,7 @@ public class ReposFragment extends Fragment implements CallbackHandler.EventList
         View view = inflater.inflate(R.layout.fragment_repos, container, false);
         unbinder = ButterKnife.bind(this, view);
 
-        mSectionedAdapter = new
-                SimpleSectionedRecyclerViewAdapter(getActivity(), R.layout.section,
+        mSectionedAdapter = new SimpleSectionedRecyclerViewAdapter(R.layout.section,
                 R.id.section_text, new ReposAdapter(fUpdateRepos, fInstalledRepos, fOthersRepos));
 
         recyclerView.setAdapter(mSectionedAdapter);

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/SimpleSectionedRecyclerViewAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/SimpleSectionedRecyclerViewAdapter.java
@@ -1,6 +1,5 @@
 package com.topjohnwu.magisk.adapters;
 
-import android.content.Context;
 import android.support.v7.widget.RecyclerView;
 import android.util.SparseArray;
 import android.view.LayoutInflater;
@@ -13,25 +12,21 @@ import java.util.Comparator;
 
 public class SimpleSectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
-    private final Context mContext;
     private static final int SECTION_TYPE = 0;
 
     private boolean mValid = true;
     private int mSectionResourceId;
     private int mTextResourceId;
-    private LayoutInflater mLayoutInflater;
     private RecyclerView.Adapter mBaseAdapter;
     private SparseArray<Section> mSections = new SparseArray<Section>();
 
 
-    public SimpleSectionedRecyclerViewAdapter(Context context, int sectionResourceId, int textResourceId,
+    public SimpleSectionedRecyclerViewAdapter(int sectionResourceId, int textResourceId,
                                               RecyclerView.Adapter baseAdapter) {
 
-        mLayoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         mSectionResourceId = sectionResourceId;
         mTextResourceId = textResourceId;
         mBaseAdapter = baseAdapter;
-        mContext = context;
 
         mBaseAdapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
             @Override
@@ -74,7 +69,7 @@ public class SimpleSectionedRecyclerViewAdapter extends RecyclerView.Adapter<Rec
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int typeView) {
         if (typeView == SECTION_TYPE) {
-            final View view = LayoutInflater.from(mContext).inflate(mSectionResourceId, parent, false);
+            View view = LayoutInflater.from(parent.getContext()).inflate(mSectionResourceId, parent, false);
             return new SectionViewHolder(view,mTextResourceId);
         }else{
             return mBaseAdapter.onCreateViewHolder(parent, typeView -1);

--- a/app/src/main/java/com/topjohnwu/magisk/utils/Async.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/Async.java
@@ -218,9 +218,8 @@ public class Async {
 
         protected boolean unzipAndCheck() {
             ZipUtils.unzip(mCachedFile, mCachedFile.getParentFile(), "META-INF/com/google/android");
-            List<String> ret;
-            ret = Utils.readFile(mCachedFile.getParent() + "/META-INF/com/google/android/updater-script");
-            return Utils.isValidShellResponse(ret) && ret.get(0).contains("#MAGISK");
+            String line = Utils.readFirstLine(mCachedFile.getParent() + "/META-INF/com/google/android/updater-script");
+            return line != null && line.contains("#MAGISK");
         }
 
         @Override

--- a/app/src/main/java/com/topjohnwu/magisk/utils/FABBehavior.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/FABBehavior.java
@@ -25,7 +25,8 @@ import java.util.List;
  * Remember to use the correct namespace for the fab:
  * xmlns:app="http://schemas.android.com/apk/res-auto"
  */
-public class FABBehavior extends CoordinatorLayout.Behavior {
+public class FABBehavior extends CoordinatorLayout.Behavior<View> {
+
     private float mTranslationY;
 
     public FABBehavior(Context context, AttributeSet attrs) {
@@ -74,11 +75,11 @@ public class FABBehavior extends CoordinatorLayout.Behavior {
 
     private float getTranslationY(CoordinatorLayout parent, View child) {
         float minOffset = 0.0F;
-        List dependencies = parent.getDependencies(child);
+        List<View> dependencies = parent.getDependencies(child);
         int i = 0;
 
         for (int z = dependencies.size(); i < z; ++i) {
-            View view = (View) dependencies.get(i);
+            View view = dependencies.get(i);
             if (view instanceof Snackbar.SnackbarLayout && parent.doViewsOverlap(child, view)) {
                 minOffset = Math.min(minOffset, ViewCompat.getTranslationY(view) - (float) view.getHeight());
             }

--- a/app/src/main/java/com/topjohnwu/magisk/utils/FABBehavior.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/FABBehavior.java
@@ -23,7 +23,7 @@ import java.util.List;
  * FabMenu in a Coordinator Layout.
  *
  * Remember to use the correct namespace for the fab:
- * xmlns:fab="http://schemas.android.com/apk/res-auto"
+ * xmlns:app="http://schemas.android.com/apk/res-auto"
  */
 public class FABBehavior extends CoordinatorLayout.Behavior {
     private float mTranslationY;

--- a/app/src/main/java/com/topjohnwu/magisk/utils/Utils.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/Utils.java
@@ -77,6 +77,17 @@ public class Utils {
         return ret;
     }
 
+    public static String readFirstLine(String path) {
+        List<String> ret;
+        String command = "head -1 " + path;
+        if (Shell.rootAccess()) {
+            ret = Shell.su(command);
+        } else {
+            ret = Shell.sh(command);
+        }
+        return isValidShellResponse(ret) ? ret.get(0) : null;
+    }
+
     public static void dlAndReceive(Context context, DownloadReceiver receiver, String link, String filename) {
         if (isDownloading) {
             return;

--- a/app/src/main/java/com/topjohnwu/magisk/utils/ZipUtils.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/ZipUtils.java
@@ -172,8 +172,7 @@ public class ZipUtils {
             inputJar = new JarMap(new JarInputStream(inputStream));
             if (signWholeFile) {
                 if (!"RSA".equalsIgnoreCase(privateKey.getAlgorithm())) {
-                    System.err.println("Cannot sign OTA packages with non-RSA keys");
-                    System.exit(1);
+                    throw new IOException("Cannot sign OTA packages with non-RSA keys");
                 }
                 signWholeFile(inputJar, context.getAssets().open(PUBLIC_KEY_NAME),
                         publicKey, privateKey, outputStream);

--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.6)
+add_library(zipadjust SHARED
+                jni_glue.c
+                zipadjust.c)
+find_library(libz z)
+find_library(liblog log)
+target_link_libraries(zipadjust ${libz} ${liblog})

--- a/app/src/main/jni/jni_glue.c
+++ b/app/src/main/jni/jni_glue.c
@@ -1,0 +1,23 @@
+//
+// Java entry point
+//
+
+#include <jni.h>
+#include <stdlib.h>
+#include "zipadjust.h"
+
+JNIEXPORT jbyteArray JNICALL
+Java_com_topjohnwu_magisk_utils_ZipUtils_zipAdjust(JNIEnv *env, jclass type, jbyteArray jbytes, jint size) {
+    fin = (*env)->GetPrimitiveArrayCritical(env, jbytes, NULL);
+    insize = (size_t) size;
+
+    zipadjust(0);
+
+    (*env)->ReleasePrimitiveArrayCritical(env, jbytes, fin, 0);
+
+    jbyteArray ret = (*env)->NewByteArray(env, outsize);
+    (*env)->SetByteArrayRegion(env, ret, 0, outsize, (const jbyte*) fout);
+    free(fout);
+
+    return ret;
+}

--- a/app/src/main/jni/zipadjust.c
+++ b/app/src/main/jni/zipadjust.c
@@ -1,35 +1,16 @@
-#include <jni.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <zlib.h>
 #include <android/log.h>
+#include "zipadjust.h"
 
 #define  LOG_TAG    "zipadjust"
 
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 
-size_t insize, outsize = 0, alloc = 0;
-unsigned char *fin, *fout;
-
-int zipadjust(int decompress) ;
-
-JNIEXPORT jbyteArray JNICALL
-Java_com_topjohnwu_magisk_utils_ZipUtils_zipAdjust(JNIEnv *env, jclass type, jbyteArray jbytes,
-                                                   jint size) {
-    fin = (*env)->GetPrimitiveArrayCritical(env, jbytes, NULL);
-    insize = (size_t) size;
-
-    zipadjust(0);
-
-    (*env)->ReleasePrimitiveArrayCritical(env, jbytes, fin, 0);
-
-    jbyteArray ret = (*env)->NewByteArray(env, outsize);
-    (*env)->SetByteArrayRegion(env, ret, 0, outsize, (const jbyte*) fout);
-    free(fout);
-
-    return ret;
-}
+size_t insize = 0, outsize = 0, alloc = 0;
+unsigned char *fin = NULL, *fout = NULL;
 
 #pragma pack(1)
 struct local_header_struct {

--- a/app/src/main/jni/zipadjust.h
+++ b/app/src/main/jni/zipadjust.h
@@ -1,0 +1,9 @@
+#ifndef MAGISKMANAGER_ZIPADJUST_H_H
+#define MAGISKMANAGER_ZIPADJUST_H_H
+
+int zipadjust(int decompress);
+
+extern size_t insize, outsize, alloc;
+extern unsigned char *fin, *fout;
+
+#endif //MAGISKMANAGER_ZIPADJUST_H_H

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -7,7 +7,6 @@
     <include layout="@layout/toolbar"/>
 
     <ScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="fill_parent"

--- a/app/src/main/res/layout/fragment_modules.xml
+++ b/app/src/main/res/layout/fragment_modules.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.SwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:fab="http://schemas.android.com/apk/res-auto"
     android:id="@+id/swipeRefreshLayout"
     android:layout_width="match_parent"
@@ -11,8 +10,6 @@
 
 
     <android.support.design.widget.CoordinatorLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/coordinator"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -25,7 +22,7 @@
             android:layout_height="match_parent"
             android:clipToPadding="false"
             android:dividerHeight="@dimen/card_divider_space"
-            app:layoutManager="android.support.v7.widget.LinearLayoutManager" />
+            fab:layoutManager="android.support.v7.widget.LinearLayoutManager" />
 
         <TextView
             android:id="@+id/empty_rv"
@@ -47,7 +44,7 @@
             android:layout_gravity="bottom|center_horizontal"
             android:layout_marginEnd="113dp"
             android:layout_marginBottom="10dp"
-            app:layout_behavior=".utils.FABBehavior"
+            fab:layout_behavior=".utils.FABBehavior"
             fab:menu_fab_size="normal"
             fab:menu_showShadow="true"
             fab:menu_shadowColor="#66000000"

--- a/app/src/main/res/layout/fragment_status.xml
+++ b/app/src/main/res/layout/fragment_status.xml
@@ -8,8 +8,7 @@
     android:layout_marginTop="?attr/actionBarSize"
     android:orientation="vertical">
 
-    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="8dp"

--- a/app/src/main/res/layout/list_item_app.xml
+++ b/app/src/main/res/layout/list_item_app.xml
@@ -22,7 +22,6 @@
         android:padding="@dimen/card_layout_padding">
 
         <ImageView
-            xmlns:android="http://schemas.android.com/apk/res/android"
             android:id="@+id/app_icon"
             android:layout_width="@dimen/card_appicon_size"
             android:layout_height="@dimen/card_appicon_size"


### PR DESCRIPTION
A bunch of small fixes that improve various things:
- clearer code (separate JNI glue from actual C code),
- cleaner code (removed redundant XML namespaces, removed context reference in recyclerview adapter),
- UI performance improvement (when programmatically closing the navigation drawer),
- memory footprint improvement (avoid loading a whole file when only the first line is necessary),
- reduced amount of compiler warnings (fixed raw use of generics),
- avoid application being closed without warning (see my comment on your commit: https://github.com/topjohnwu/MagiskManager/commit/f58c73b7f16a451d5c7571246685ac14716c3354#diff-5c46eb695249ea09b7615aa0941001f8)

I moved the ```CMakeLists.txt``` file from the root of  the ```app``` module to the ```app/src/main/jni/``` folder in order to follow the example of google in their repo: https://github.com/googlesamples/android-ndk (this makefile is made for the C code in the ```main/jni/``` folder, so we should put it in there)