### PR TITLE
Code cleaning, fix a Lint error

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/MainActivity.java
@@ -180,7 +180,7 @@ public class MainActivity extends AppCompatActivity
 
     private void displayFragment(@NonNull Fragment navFragment, String tag, boolean setElevation) {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-        invalidateOptionsMenu();
+        supportInvalidateOptionsMenu();
         transaction.setCustomAnimations(android.R.anim.fade_in, android.R.anim.fade_out);
         transaction.replace(R.id.content_frame, navFragment, tag).commitNow();
         if (setElevation) toolbar.setElevation(toolbarElevation);

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/PolicyAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/PolicyAdapter.java
@@ -21,6 +21,7 @@ import com.topjohnwu.magisk.utils.Utils;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -30,7 +31,7 @@ public class PolicyAdapter extends RecyclerView.Adapter<PolicyAdapter.ViewHolder
     private List<Policy> policyList;
     private SuDatabaseHelper dbHelper;
     private PackageManager pm;
-    private HashSet<Policy> expandList = new HashSet<>();
+    private Set<Policy> expandList = new HashSet<>();
 
     public PolicyAdapter(List<Policy> list, SuDatabaseHelper db, PackageManager pm) {
         policyList = list;

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/ReposAdapter.java
@@ -24,6 +24,7 @@ import com.topjohnwu.magisk.utils.WebWindow;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -31,7 +32,7 @@ import butterknife.ButterKnife;
 public class ReposAdapter extends RecyclerView.Adapter<ReposAdapter.ViewHolder> {
 
     private List<Repo> mUpdateRepos, mInstalledRepos, mOthersRepos;
-    private HashSet<Repo> expandList = new HashSet<>();
+    private Set<Repo> expandList = new HashSet<>();
 
     public ReposAdapter(List<Repo> update, List<Repo> installed, List<Repo> others) {
         mUpdateRepos = update;

--- a/app/src/main/java/com/topjohnwu/magisk/adapters/SuLogAdapter.java
+++ b/app/src/main/java/com/topjohnwu/magisk/adapters/SuLogAdapter.java
@@ -22,10 +22,11 @@ import com.topjohnwu.magisk.R;
 import com.topjohnwu.magisk.superuser.SuLogEntry;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -33,13 +34,13 @@ import butterknife.ButterKnife;
 public class SuLogAdapter {
 
     private ExpandableAdapter adapter;
-    private HashSet<SuLogEntry> expandList = new HashSet<>();
+    private Set<SuLogEntry> expandList = new HashSet<>();
 
     public SuLogAdapter(List<SuLogEntry> list) {
 
         // Separate the logs with date
-        LinkedHashMap<String, ArrayList<SuLogEntry>> logEntryMap = new LinkedHashMap<>();
-        ArrayList<SuLogEntry> group;
+        Map<String, List<SuLogEntry>> logEntryMap = new LinkedHashMap<>();
+        List<SuLogEntry> group;
         for (SuLogEntry log : list) {
             String date = log.getDateString();
             group = logEntryMap.get(date);
@@ -51,8 +52,8 @@ public class SuLogAdapter {
         }
 
         // Then format them into expandable groups
-        ArrayList<LogGroup> logEntryGroups = new ArrayList<>();
-        for (HashMap.Entry<String, ArrayList<SuLogEntry>> entry : logEntryMap.entrySet()) {
+        List<LogGroup> logEntryGroups = new ArrayList<>();
+        for (Map.Entry<String, List<SuLogEntry>> entry : logEntryMap.entrySet()) {
             logEntryGroups.add(new LogGroup(entry.getKey(), entry.getValue()));
         }
         adapter = new ExpandableAdapter(logEntryGroups);

--- a/app/src/main/java/com/topjohnwu/magisk/module/ModuleHelper.java
+++ b/app/src/main/java/com/topjohnwu/magisk/module/ModuleHelper.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class ModuleHelper {
 
@@ -70,7 +71,7 @@ public class ModuleHelper {
             jsonString = prefs.getString(REPO_KEY, null);
         }
 
-        ValueSortedMap<String, Repo> cached = null;
+        Map<String, Repo> cached = null;
 
         if (jsonString != null) {
             cached = gson.fromJson(jsonString, new TypeToken<ValueSortedMap<String, Repo>>(){}.getType());
@@ -82,7 +83,7 @@ public class ModuleHelper {
 
         // Get cached ETag to add in the request header
         String etag = prefs.getString(ETAG_KEY, "");
-        HashMap<String, String> header = new HashMap<>();
+        Map<String, String> header = new HashMap<>();
         header.put("If-None-Match", etag);
 
         // Making a request to main URL for repo info

--- a/app/src/main/java/com/topjohnwu/magisk/utils/CallbackHandler.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/CallbackHandler.java
@@ -17,10 +17,9 @@ public class CallbackHandler {
     }
 
     public static void unRegister(Event event) {
-        HashSet<EventListener> list = listeners.get(event);
+        HashSet<EventListener> list = listeners.remove(event);
         if (list != null) {
             list.clear();
-            listeners.remove(event);
         }
     }
 

--- a/app/src/main/java/com/topjohnwu/magisk/utils/CallbackHandler.java
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/CallbackHandler.java
@@ -2,13 +2,15 @@ package com.topjohnwu.magisk.utils;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class CallbackHandler {
 
-    private static HashMap<Event, HashSet<EventListener>> listeners = new HashMap<>();
+    private static Map<Event, Set<EventListener>> listeners = new HashMap<>();
 
     public static void register(Event event, EventListener listener) {
-        HashSet<EventListener> list = listeners.get(event);
+        Set<EventListener> list = listeners.get(event);
         if (list == null) {
             list = new HashSet<>();
             listeners.put(event, list);
@@ -17,21 +19,21 @@ public class CallbackHandler {
     }
 
     public static void unRegister(Event event) {
-        HashSet<EventListener> list = listeners.remove(event);
+        Set<EventListener> list = listeners.remove(event);
         if (list != null) {
             list.clear();
         }
     }
 
     public static void unRegister(Event event, EventListener listener) {
-        HashSet<EventListener> list = listeners.get(event);
+        Set<EventListener> list = listeners.get(event);
         if (list != null) {
             list.remove(listener);
         }
     }
 
     private static void triggerCallback(Event event) {
-        HashSet<EventListener> list = listeners.get(event);
+        Set<EventListener> list = listeners.get(event);
         if (list != null) {
             for (EventListener listener : list) {
                 listener.onTrigger(event);


### PR DESCRIPTION
In order to make the code a tad bit cleaner, prefer the use of interfaces as declaring type when you don't need to call a method declared only in a particular implementation (thus you can avoid being limited to specific implementations).
Here are some changes regarding some declarations of lists, sets or maps.

When using ```AppCompatActivity``` some methods are restricted in order to handle Android API changes, we have to use ```support*()``` methods instead.
Here is a fix for the Lint error generated when using ```invalidateOptionsMenu()``` directly.