### PR TITLE
 settings: Remove request timeout if auto response is set to 'grant'

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/SettingsActivity.java
+++ b/app/src/main/java/com/topjohnwu/magisk/SettingsActivity.java
@@ -132,6 +132,11 @@ public class SettingsActivity extends Activity implements Topic.Subscriber {
                     prefScreen.removePreference(magiskCategory);
                 }
             }
+            
+            // Remove request timeout if Auto response is set to 'grant'
+            if (autoRes.getValue() == 2) {
+                prefScreen.removePreference(requestTimeout);
+            }
         }
 
         private void setLocalePreference(ListPreference lp) {


### PR DESCRIPTION
Request timeout becomes useless once user sets the Auto response to "Grant".

Please review in case I missed anything.