### PR TITLE
Fix color of LogFragment menu items when using dark theme

### DIFF
--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -4,6 +4,6 @@
         android:viewportHeight="24.0"
         android:viewportWidth="24.0">
     <path
-        android:fillColor="#000"
+        android:fillColor="?attr/imageColorTint"
         android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_refresh.xml
+++ b/app/src/main/res/drawable/ic_refresh.xml
@@ -4,6 +4,6 @@
         android:viewportHeight="24.0"
         android:viewportWidth="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/imageColorTint"
         android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_save.xml
+++ b/app/src/main/res/drawable/ic_save.xml
@@ -4,6 +4,6 @@
         android:viewportHeight="24.0"
         android:viewportWidth="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/imageColorTint"
         android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
 </vector>

--- a/app/src/main/res/layout/fragment_magisk.xml
+++ b/app/src/main/res/layout/fragment_magisk.xml
@@ -178,8 +178,7 @@
                             android:layout_centerVertical="true"
                             android:layout_margin="15dp"
                             android:layout_toStartOf="@+id/safetyNet_status"
-                            android:src="@drawable/ic_refresh"
-                            android:tint="?attr/imageColorTint" />
+                            android:src="@drawable/ic_refresh" />
 
                         <ProgressBar
                             android:id="@+id/safetyNet_check_progress"


### PR DESCRIPTION
I set the color directly in the ic_*.xml files instead of using android:iconTint in menu_log.xml (as seen in fragment_magisk.xml) because iconTint is API26+.

As the refresh icon is also used in fragment_magisk.xml, I removed the now unnecessary android:tint from there.

Another way would be to tint the icons in Java, but I think it makes no sense to define colors for icons when you overwrite them everywhere anyway. Also, just XML is nicer.