### PR TITLE
Expose Flashing colours for themes

### DIFF
--- a/app/src/main/res/layout/activity_flash.xml
+++ b/app/src/main/res/layout/activity_flash.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:background="@android:color/black"
+    android:background="@color/flashing_background_color"
     tools:context="com.topjohnwu.magisk.FlashActivity">
 
     <include layout="@layout/toolbar"/>
@@ -31,7 +31,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
-        android:background="@android:color/darker_gray"
+        android:background="@color/button_panel_background_color"
         android:orientation="horizontal"
         android:visibility="gone">
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,4 +17,8 @@
 
     <color name="su_request_background">#e0e0e0</color>
 
+
+<!-- Flashing colors -->
+    <color name="flashing_background_color">@android:color/black</color>
+    <color name="button_panel_background_color">@android:color/darker_gray</color>
 </resources>


### PR DESCRIPTION
This pull request will help expose the colours in the Flashing activity for themes. At present, if we add the activity_flash layout xml into our themes then the text disappears due to the classes defined in the layout.