### PR TITLE
Update strings - Italian (again!)

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -28,7 +28,7 @@
     <!--Install Fragment-->
     <string name="auto_detect">%1$s (auto)</string>
     <string name="cannot_auto_detect">(Impossibile rilevare automaticamente)</string>
-    <string name="boot_image_title">Percorso dell'immagine di boot</string>
+    <string name="boot_image_title">Percorso dell\'immagine di boot</string>
     <string name="detect_button">Rileva</string>
     <string name="advanced_settings_title">Impostazioni avanzate</string>
     <string name="keep_force_encryption">Mantieni la crittografia forzata</string>
@@ -106,22 +106,22 @@
     <string name="magisk_updates">Aggiornamento Magisk</string>
     <string name="flashing">Flash in corso…</string>
     <string name="hide_manager_toast">Nascondendo Magisk Manager…</string>
-    <string name="hide_manager_toast2">Potrebbe volerci un po'…</string>
+    <string name="hide_manager_toast2">Potrebbe volerci un po\'…</string>
     <string name="hide_manager_fail_toast">Non è stato possibile nascondere Magisk Manager</string>
     <string name="download_zip_only">Scarica solo il file zip</string>
-    <string name="patch_boot_file">Aggiorna l'immagine di boot</string>
+    <string name="patch_boot_file">Aggiorna l\'immagine di boot</string>
     <string name="direct_install">Installazione diretta (raccomandata)</string>
     <string name="install_second_slot">Installa nel secondo slot (dopo OTA)</string>
     <string name="select_method">Seleziona un metodo</string>
-    <string name="no_boot_file_patch_support">La versione Magisk di destinazione non supporta l'aggiornamento dell'immagine di boot</string>
-    <string name="boot_file_patch_msg">Seleziona l'immagine originale di boot in formato .img o img.tar</string>
+    <string name="no_boot_file_patch_support">La versione Magisk di destinazione non supporta l\'aggiornamento dell\'immagine di boot</string>
+    <string name="boot_file_patch_msg">Seleziona l\'immagine originale di boot in formato .img o img.tar</string>
     <string name="complete_uninstall">Completa disinstallazione</string>
-    <string name="restore_stock_boot">Ripristina l'immagine originale di boot</string>
+    <string name="restore_stock_boot">Ripristina l\'immagine originale di boot</string>
     <string name="restore_done">Ripristino completato!</string>
-    <string name="restore_fail">Non esiste un'immagine originale di boot!</string>
+    <string name="restore_fail">Non esiste un\'immagine originale di boot!</string>
     <string name="uninstall_toast">Disinstallazione di Magisk Manager in 5 secondi, riavvia manualmente per completare</string>
     <string name="proprietary_title">Scarica codice proprietario</string>
-    <string name="proprietary_notice">Magisk Manager è FOSS, quindi non contiene il codice proprietario delle API Google SafetyNet.\n\nVuoi permettere il download di un'estensione (che contiene GoogleApiClient) per controllare lo stato di SafetyNet?</string>
+    <string name="proprietary_notice">Magisk Manager è FOSS, quindi non contiene il codice proprietario delle API Google SafetyNet.\n\nVuoi permettere il download di un\'estensione (che contiene GoogleApiClient) per controllare lo stato di SafetyNet?</string>
 
     <!--Settings Activity -->
     <string name="settings_general_category">Generale</string>
@@ -139,8 +139,8 @@
     <string name="settings_update_channel_title">Canale di aggiornamento</string>
     <string name="settings_update_stable">Stabile</string>
     <string name="settings_update_beta">Beta</string>
-    <string name="settings_boot_format_title">Formato dell'immagine di boot aggiornata</string>    
-    <string name="settings_boot_format_summary">Seleziona il formato nel quale l'immagine di boot verrà salvata. .\nSeleziona .img per il flash in fastboot/download mode; Seleziona .img.tar per il flash con Odin.</string>													   
+    <string name="settings_boot_format_title">Formato dell\'immagine di boot aggiornata</string>    
+    <string name="settings_boot_format_summary">Seleziona il formato nel quale l\'immagine di boot verrà salvata. .\nSeleziona .img per il flash in fastboot/download mode; Seleziona .img.tar per il flash con Odin.</string>													   
     <string name="settings_core_only_title">Modalità Magisk Core</string>							
     <string name="settings_core_only_summary">Abilita solo le funzioni principali. Nessun modulo verrà caricato. MagiskSU, MagiskHide e host systemless rimarranno abilitati</string>
     <string name="settings_magiskhide_summary">Nasconde Magisk da numerose rilevazioni</string>			


### PR DESCRIPTION
**Urgent correction!**
Many strings now contain the following character
**'**
It needs a backslash \ typed in front, otherwise sentences are cut!
Sorry about this, but I could not test translations until a new version was released (5.4.1)