### PR TITLE
request focus for grant button to enable dpad nav

### DIFF
--- a/src/main/java/com/topjohnwu/magisk/superuser/RequestActivity.java
+++ b/src/main/java/com/topjohnwu/magisk/superuser/RequestActivity.java
@@ -131,6 +131,7 @@ public class RequestActivity extends Activity {
             handleAction(Policy.ALLOW);
             timer.cancel();
         });
+        grant_btn.requestFocus();
         deny_btn.setOnClickListener(v -> {
             handleAction(Policy.DENY);
             timer.cancel();


### PR DESCRIPTION
if no buttons have focus, it is impossible to use
on android tv without hooking up a mouse