### PR TITLE
Clean up install directory when patch failed

### DIFF
--- a/src/main/java/com/topjohnwu/magisk/asyncs/InstallMagisk.java
+++ b/src/main/java/com/topjohnwu/magisk/asyncs/InstallMagisk.java
@@ -176,8 +176,10 @@ public class InstallMagisk extends ParallelTask<Void, Void, Boolean> {
                                     "sh update-binary indep boot_patch.sh %s || echo 'Failed!'",
                             mm.keepEnc, mm.keepVerity, highCompression, boot));
 
-            if (TextUtils.equals(console.get(console.size() - 1), "Failed!"))
+            if (TextUtils.equals(console.get(console.size() - 1), "Failed!")) {
+                Shell.Sync.sh("rm -rf " + install);
                 return false;
+            }
 
             Shell.Sync.sh("mv -f new-boot.img ../",
                     "mv bin/busybox busybox",


### PR DESCRIPTION
Due to a misconfiguration in ZenFone 4 Oreo upgrade MagiskManager fails patching boot.img and leaves incomplete install folder without busybox. When user installs Magisk via TWRP and reboots the device the /data/adb/magisk will be overrided by that folder. Without busybox and strange vender shell (no grep, unzip .. ) MagiskManager will fail to install most of the modules.

Signed-off-by: Shaka Huang <shakalaca@gmail.com>