### PR TITLE
Move request time out "forever" to end of array

### DIFF
--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="allow_timeout">
-        <item>@string/forever</item>
         <item>@string/once</item>
         <item>@string/tenmin</item>
         <item>@string/twentymin</item>
         <item>@string/thirtymin</item>
         <item>@string/sixtymin</item>
+        <item>@string/forever</item>
     </string-array>
 
     <string-array name="su_access">


### PR DESCRIPTION
Move the 'forever' option to the end of the request time out list.  This serves the purpose of preventing users from accidentally authorizing applications or the `su` binary indefinitely which may have unintended long-term effects.  By moving the 'forever' option to the end it also orders the list by length of time and makes 'once' the first option which allows for fast acceptance.