### PR TITLE
Delete outdated policy

### DIFF
--- a/src/full/java/com/topjohnwu/magisk/container/Policy.java
+++ b/src/full/java/com/topjohnwu/magisk/container/Policy.java
@@ -29,6 +29,8 @@ public class Policy implements Comparable<Policy>{
 
     public Policy(Cursor c, PackageManager pm) throws PackageManager.NameNotFoundException {
         uid = c.getInt(c.getColumnIndex("uid"));
+        String[] pkgs = pm.getPackagesForUid(uid);
+        if (pkgs == null || pkgs.length == 0) throw new PackageManager.NameNotFoundException();
         packageName = c.getString(c.getColumnIndex("package_name"));
         policy = c.getInt(c.getColumnIndex("policy"));
         until = c.getLong(c.getColumnIndex("until"));

--- a/src/full/java/com/topjohnwu/magisk/database/MagiskDatabaseHelper.java
+++ b/src/full/java/com/topjohnwu/magisk/database/MagiskDatabaseHelper.java
@@ -203,6 +203,7 @@ public class MagiskDatabaseHelper {
     }
 
     public void addPolicy(Policy policy) {
+        deletePolicy(policy.packageName);
         db.replace(POLICY_TABLE, null, policy.getContentValues());
     }
 


### PR DESCRIPTION
Force stop Magisk Manager, uninstall a app, reinstall the app(has new uid), request root. The outdated policy won't be deleted, two items are displayed together in the superuser list.